### PR TITLE
Auto-Scroll Chat Container

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -27,13 +27,9 @@ body {
     display: none;
     margin: 0 auto;
     overflow: auto;
+    max-height: 70vh;
   }
   
-  #chat-history {
-    overflow-y: auto;
-  }
-
-
 .copy-button {
   position: absolute;
   bottom: 5px;

--- a/chat.js
+++ b/chat.js
@@ -33,9 +33,14 @@ function getSelectedModel() {
   return document.getElementById('model-select').value;
 }
 
+function scrollToBottom(ele) {
+  ele.scrollTop = ele.scrollHeight;
+}
+
 // Function to handle the user input and call the API functions
 async function submitRequest() {
-  document.getElementById('chat-container').style.display = 'block';
+  const chatContainer = document.getElementById('chat-container')
+  chatContainer.style.display = 'block';
 
   const input = document.getElementById('user-input').value;
   const selectedModel = getSelectedModel();
@@ -69,6 +74,8 @@ async function submitRequest() {
   }
   // add button after responseDiv
   responseDiv.insertAdjacentElement('afterend', stopButton);
+  // autoscroll
+  scrollToBottom(chatContainer);
   
   postRequest(data, interrupt.signal)
     .then(async response => {
@@ -96,6 +103,8 @@ async function submitRequest() {
           }
           responseDiv.hidden_text += word;
           responseDiv.innerHTML = DOMPurify.sanitize(marked.parse(responseDiv.hidden_text)); // Append word to response container
+          // autoscrolls chat container
+          scrollToBottom(chatContainer);
         }
       });
     })

--- a/chat.js
+++ b/chat.js
@@ -67,11 +67,12 @@ async function submitRequest() {
   stopButton.onclick = () => {
     interrupt.abort('Stop button pressed');
   }
-  // add button after responseDiv
-  responseDiv.insertAdjacentElement('afterend', stopButton);
+  // add button after chatContainer
+  const chatContainer = document.getElementById('chat-container')
+  chatContainer.insertAdjacentElement('afterend', stopButton);
   // autoscroll when new line is added
   const autoScroller = new ResizeObserver(() => {
-    stopButton.scrollIntoView({behavior: "smooth", block: "end"});
+    chatHistory.scrollIntoView({behavior: "smooth", block: "end"});
   });
   autoScroller.observe(responseDiv);
 

--- a/chat.js
+++ b/chat.js
@@ -33,14 +33,9 @@ function getSelectedModel() {
   return document.getElementById('model-select').value;
 }
 
-function scrollToBottom(ele) {
-  ele.scrollTop = ele.scrollHeight;
-}
-
 // Function to handle the user input and call the API functions
 async function submitRequest() {
-  const chatContainer = document.getElementById('chat-container')
-  chatContainer.style.display = 'block';
+  document.getElementById('chat-container').style.display = 'block';
 
   const input = document.getElementById('user-input').value;
   const selectedModel = getSelectedModel();
@@ -74,8 +69,12 @@ async function submitRequest() {
   }
   // add button after responseDiv
   responseDiv.insertAdjacentElement('afterend', stopButton);
-  // autoscroll
-  scrollToBottom(chatContainer);
+  // autoscroll when new line is added
+  const autoScroller = new ResizeObserver(() => {
+    stopButton.scrollIntoView({behavior: "smooth", block: "end"});
+  });
+  autoScroller.observe(responseDiv);
+
   
   postRequest(data, interrupt.signal)
     .then(async response => {
@@ -103,8 +102,6 @@ async function submitRequest() {
           }
           responseDiv.hidden_text += word;
           responseDiv.innerHTML = DOMPurify.sanitize(marked.parse(responseDiv.hidden_text)); // Append word to response container
-          // autoscrolls chat container
-          scrollToBottom(chatContainer);
         }
       });
     })

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 
 <body class="bg-light">
     <div class="container">
-        <div class="row pt-5">
+        <div class="row pt-3">
             <div class="col-8">
                 <h1>Chat with Llama2</h1>
             </div>
@@ -31,7 +31,7 @@
         </div>
         <div id="chat-container" class="card">
             <div class="card-body">
-                <div id="chat-history"></div>
+                <div id="chat-history" class="py-2"></div>
             </div>
         </div>
         <div class="input-group mt-3" id="input-area">

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         </div>
         <div id="chat-container" class="card">
             <div class="card-body">
-                <div id="chat-history" class="py-2"></div>
+                <div id="chat-history" class="pb-2"></div>
             </div>
         </div>
         <div class="input-group mt-3" id="input-area">

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         </div>
         <div id="chat-container" class="card">
             <div class="card-body">
-                <div id="chat-history" class="pb-2"></div>
+                <div id="chat-history" class="py-2"></div>
             </div>
         </div>
         <div class="input-group mt-3" id="input-area">

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 </head>
 
 <body class="bg-light">
-    <div class="container mt-5">
-        <div class="row">
+    <div class="container">
+        <div class="row pt-5">
             <div class="col-8">
                 <h1>Chat with Llama2</h1>
             </div>


### PR DESCRIPTION
Replaces the full-page scroll with scrolling only within the chat container. Chat container height is capped at 70vh and stops expanding when that threshold is reached. Auto-scrolls to the bottom of the chat whenever a new line is added to the response. 

I moved the 'Stop' button outside the chat container because it looked a little strange when it scrolled and thought it would be best if it remained stationary when the chat container is at its max height so users can click on it if necessary.