### PR TITLE
Auto Scrolling Chat History responsive to scroll events, Model name saved as URL Param

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -29,14 +29,21 @@ body {
     overflow: auto;
   }
   
-  #chat-history {
-    overflow-y: auto;
-  }
-
-
 .copy-button {
   position: absolute;
   bottom: 5px;
   right: 5px;
   margin: 0 5px 5px 0;
 }
+
+#scroll-wrapper {
+  padding-bottom: 5.5rem;
+}
+
+#input-area {
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+

--- a/chat.js
+++ b/chat.js
@@ -10,6 +10,11 @@ marked.use({
   headerIds: false
 });
 
+function autoFocusInput() {
+  const userInput = document.getElementById('user-input');
+  userInput.focus();
+}
+
 /*
 takes in model as a string
 updates the query parameters of page url to include model name
@@ -61,8 +66,6 @@ async function populateModels() {
   catch (error) {
     console.error(error);
   }
-
-
 }
 
 // adjusts the padding at the bottom of scrollWrapper to be the height of the input box
@@ -220,6 +223,7 @@ document.getElementById('user-input').addEventListener('keydown', function (e) {
 
 
 window.onload = () => {
-  adjustPadding();
   populateModels();
+  adjustPadding();
+  autoFocusInput();
 }

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 </head>
 
 <body class="bg-light">
-    <div class="container mt-5">
-        <div class="row">
+    <div class="container">
+        <div class="row pt-3">
             <div class="col-8">
                 <h1>Chat with Llama2</h1>
             </div>
@@ -29,16 +29,21 @@
                 <select class="form-select d-inline-block" id="model-select" style="width: auto;"></select>
             </div>
         </div>
-        <div id="chat-container" class="card">
-            <div class="card-body">
-                <div id="chat-history"></div>
+        <div id="scroll-wrapper">
+            <div id="chat-container" class="card">
+                <div class="card-body">
+                    <div id="chat-history"></div>
+                </div>
             </div>
         </div>
-        <div class="input-group mt-3" id="input-area">
+    </div>
+    <div class="container p-2 bg-light card" id="input-area">
+        <div class="input-group">
             <textarea class="form-control" id="user-input" placeholder="Type your question here..."></textarea>
             <button id="send-button" class="btn btn-primary">Send</button>
         </div>
     </div>
+
     <script src="api.js"></script>
     <script src="chat.js"></script>
 </body>


### PR DESCRIPTION
Automatically scrolls to the bottom of the chat whenever the div containing the llama response expands. The user does not have to manually scroll to read the response from the chat.

In order to implement this, the user input text box is fixed to the bottom of the screen.

Auto scroll automatically toggles on and off based on user scroll actions. For instance, if the user scrolls up, auto scroll shuts off. If the user scrolls down near the bottom of the page to the latest response, auto scroll turns back on again.

When the user selects a model, the model name is pushed to the URL as a query param. The query param is read upon page load and if a matching model name exists, the model is automatically selected. This enables model selection to persist even if the page reloads. If a user selects orca:latest for example, the URL becomes http://localhost:8000?model=orca%3Alatest and orca:latest is auto-selected in the model select drop down upon refresh.

I also made a tiny window.onLoad change that automatically selects the input box on page load. If this is not desired behavior the last commit can be removed. 
